### PR TITLE
Stop Visual Studio from quitting when project contains <PackageReference>

### DIFF
--- a/src/VSPackage.cs
+++ b/src/VSPackage.cs
@@ -95,7 +95,7 @@ namespace StringResourceVisualizer
 
         private void HandleOpenSolution(object sender, EventArgs e)
         {
-            JoinableTaskFactory.RunAsync(HandleOpenSolutionAsync).Task.LogAndForget(GetType());
+            JoinableTaskFactory.RunAsync(HandleOpenSolutionAsync).Task.LogAndForget("StringResourceVisualizer");
         }
 
         private async Task HandleOpenSolutionAsync()
@@ -210,15 +210,11 @@ namespace StringResourceVisualizer
 
     static class TaskExtensions
     {
-        internal static void LogAndForget(this Task task, Type type)
-        {
-            task.ContinueWith(t =>
-            {
-                if (t.Exception != null)
-                {
-                    VsShellUtilities.LogError(type.FullName, t.Exception.ToString());
-                }
-            });
-        }
+        internal static void LogAndForget(this Task task, string source) =>
+            task.ContinueWith((t, s) => VsShellUtilities.LogError(s as string, t.Exception.ToString()),
+                source,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                TaskScheduler.FromCurrentSynchronizationContext());
     }
 }

--- a/src/VSPackage.cs
+++ b/src/VSPackage.cs
@@ -75,7 +75,7 @@ namespace StringResourceVisualizer
 
             if (isSolutionLoaded)
             {
-                await HandleOpenSolutionAsync();
+                await HandleOpenSolutionAsync(cancellationToken);
             }
 
             // Listen for subsequent solution events
@@ -95,12 +95,12 @@ namespace StringResourceVisualizer
 
         private void HandleOpenSolution(object sender, EventArgs e)
         {
-            JoinableTaskFactory.RunAsync(HandleOpenSolutionAsync).Task.LogAndForget("StringResourceVisualizer");
+            JoinableTaskFactory.RunAsync(() => HandleOpenSolutionAsync(CancellationToken.None)).Task.LogAndForget("StringResourceVisualizer");
         }
 
-        private async Task HandleOpenSolutionAsync()
+        private async Task HandleOpenSolutionAsync(CancellationToken cancellationToken)
         {
-            await JoinableTaskFactory.SwitchToMainThreadAsync();
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             //Use nested methods to avoid prompt (and need) for multiple MainThead checks/switches
             IEnumerable<ProjectItem> RecurseProjectItems(ProjectItems projItems)

--- a/src/VSPackage.cs
+++ b/src/VSPackage.cs
@@ -71,7 +71,7 @@ namespace StringResourceVisualizer
 
             // Since this package might not be initialized until after a solution has finished loading,
             // we need to check if a solution has already been loaded and then handle it.
-            bool isSolutionLoaded = await IsSolutionLoadedAsync();
+            bool isSolutionLoaded = await IsSolutionLoadedAsync(cancellationToken);
 
             if (isSolutionLoaded)
             {
@@ -82,9 +82,9 @@ namespace StringResourceVisualizer
             SolutionEvents.OnAfterOpenSolution += HandleOpenSolution;
         }
 
-        private async Task<bool> IsSolutionLoadedAsync()
+        private async Task<bool> IsSolutionLoadedAsync(CancellationToken cancellationToken)
         {
-            await JoinableTaskFactory.SwitchToMainThreadAsync();
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             var solService = await GetServiceAsync(typeof(SVsSolution)) as IVsSolution;
 

--- a/src/VSPackage.cs
+++ b/src/VSPackage.cs
@@ -159,7 +159,6 @@ namespace StringResourceVisualizer
                             // Only want neutral language ones, not locale specific versions
                             if (!System.IO.Path.GetFileNameWithoutExtension(filePath).Contains("."))
                             {
-                                Console.WriteLine(filePath);
                                 ResourceAdornmentManager.ResourceFiles.Add(filePath);
                             }
                         }

--- a/src/VSPackage.cs
+++ b/src/VSPackage.cs
@@ -141,6 +141,8 @@ namespace StringResourceVisualizer
             {
                 foreach (var project in dte.Solution.Projects)
                 {
+                    await Task.Yield(); // Avoid blocking the [UI] thread continually if there are lots of projects in the solution.
+
                     foreach (var solFile in GetProjectFiles((Project)project))
                     {
                         if (solFile.Kind != EnvDTE.Constants.vsProjectItemKindPhysicalFile)

--- a/src/VSPackage.cs
+++ b/src/VSPackage.cs
@@ -143,7 +143,8 @@ namespace StringResourceVisualizer
                 {
                     foreach (var solFile in GetProjectFiles((Project)project))
                     {
-                        var filePath = solFile.FileNames[0];
+                        // The index of file names from 1 to FileCount for the project item.
+                        var filePath = solFile.FileNames[1];
                         var fileExt = System.IO.Path.GetExtension(filePath);
 
                         // Only interested in resx files

--- a/src/VSPackage.cs
+++ b/src/VSPackage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -74,7 +75,7 @@ namespace StringResourceVisualizer
 
             if (isSolutionLoaded)
             {
-                HandleOpenSolution();
+                await HandleOpenSolutionAsync();
             }
 
             // Listen for subsequent solution events
@@ -92,9 +93,14 @@ namespace StringResourceVisualizer
             return value is bool isSolOpen && isSolOpen;
         }
 
-        private async void HandleOpenSolution(object sender = null, EventArgs e = null)
+        private void HandleOpenSolution(object sender, EventArgs e)
         {
-            await this.JoinableTaskFactory.SwitchToMainThreadAsync();
+            JoinableTaskFactory.RunAsync(HandleOpenSolutionAsync).Task.FileAndForget("StringResourceVisualizer");
+        }
+
+        private async Task HandleOpenSolutionAsync()
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync();
 
             //Use nested methods to avoid prompt (and need) for multiple MainThead checks/switches
             IEnumerable<ProjectItem> RecurseProjectItems(ProjectItems projItems)

--- a/src/VSPackage.cs
+++ b/src/VSPackage.cs
@@ -95,7 +95,7 @@ namespace StringResourceVisualizer
 
         private void HandleOpenSolution(object sender, EventArgs e)
         {
-            JoinableTaskFactory.RunAsync(() => HandleOpenSolutionAsync(CancellationToken.None)).Task.LogAndForget("StringResourceVisualizer");
+            JoinableTaskFactory.RunAsync(() => HandleOpenSolutionAsync(DisposalToken)).Task.LogAndForget("StringResourceVisualizer");
         }
 
         private async Task HandleOpenSolutionAsync(CancellationToken cancellationToken)

--- a/src/VSPackage.cs
+++ b/src/VSPackage.cs
@@ -75,7 +75,7 @@ namespace StringResourceVisualizer
 
             if (isSolutionLoaded)
             {
-                HandleOpenSolution(null, null);
+                await HandleOpenSolutionAsync();
             }
 
             // Listen for subsequent solution events
@@ -205,10 +205,6 @@ namespace StringResourceVisualizer
                 var plural = ResourceAdornmentManager.ResourceFiles.Count > 1 ? "s" : string.Empty;
                 dte.StatusBar.Text = $"String Resource Visualizer initialized with {ResourceAdornmentManager.ResourceFiles.Count} resource file{plural}.";
             }
-        }
-
-        private void ErrorLogger(Task task)
-        {
         }
     }
 

--- a/src/VSPackage.cs
+++ b/src/VSPackage.cs
@@ -214,6 +214,6 @@ namespace StringResourceVisualizer
                 source,
                 CancellationToken.None,
                 TaskContinuationOptions.OnlyOnFaulted,
-                TaskScheduler.FromCurrentSynchronizationContext());
+                VsTaskLibraryHelper.GetTaskScheduler(VsTaskRunContext.UIThreadNormalPriority));
     }
 }

--- a/src/VSPackage.cs
+++ b/src/VSPackage.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -143,6 +142,12 @@ namespace StringResourceVisualizer
                 {
                     foreach (var solFile in GetProjectFiles((Project)project))
                     {
+                        if (solFile.Kind != EnvDTE.Constants.vsProjectItemKindPhysicalFile)
+                        {
+                            // We're only interested in files
+                            continue;
+                        }
+
                         // The index of file names from 1 to FileCount for the project item.
                         var filePath = solFile.FileNames[1];
                         var fileExt = System.IO.Path.GetExtension(filePath);


### PR DESCRIPTION
### What this PR does

Fixes #9

- Catch any exceptions thrown by `HandleOpenSolution` and `FileAndForget`
- Get file path `ProjectItem.FileNames[1]` because it's a 1 based array [see](https://docs.microsoft.com/en-us/dotnet/api/envdte.projectitem.filenames?view=visualstudiosdk-2017)
- Only consider `ProjectItem.Kind=PhysicalFile` for inclusion (package references causing an error)
- Add `LogAndForget` extension method for logging task exceptions to the Visual Studio log

I thought `JoinableTask.FileAndForget` would do this ☝️, but exceptions don't seem to appear in the log. 😕 @AArnott is there a trick to making `FileAndForget` exceptions appear in the log?

Here's the smoking gun.
![image](https://user-images.githubusercontent.com/11719160/48659681-f1cda380-ea4c-11e8-8cbb-b14b0c02e283.png)

It does appear to be `<PackageReference>` related.